### PR TITLE
Replace Fabric Loader internals to fix for Quilt

### DIFF
--- a/src/main/java/net/zatrit/openmcskins/OpenMCSkins.java
+++ b/src/main/java/net/zatrit/openmcskins/OpenMCSkins.java
@@ -3,8 +3,7 @@ package net.zatrit.openmcskins;
 import com.google.common.hash.HashFunction;
 import me.shedaniel.autoconfig.AutoConfig;
 import net.fabricmc.loader.api.FabricLoader;
-import net.fabricmc.loader.impl.util.version.SemanticVersionImpl;
-import net.fabricmc.loader.util.version.SemanticVersionPredicateParser;
+import net.fabricmc.loader.api.metadata.version.VersionPredicate;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
 import net.minecraft.client.network.PlayerListEntry;
@@ -75,11 +74,11 @@ public class OpenMCSkins {
         }
     }
 
-    @SuppressWarnings({"deprecation", "OptionalGetWithoutIsPresent"})
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
     public static boolean isModLoaded(String name, String version) {
         try {
-            final var predicate = SemanticVersionPredicateParser.create(version);
-            final var modVersion = new SemanticVersionImpl(FabricLoader.getInstance().getModContainer(name).get().getMetadata().getVersion().getFriendlyString(), false);
+            final var predicate = VersionPredicate.parse(version);
+            final var modVersion = FabricLoader.getInstance().getModContainer(name).get().getMetadata().getVersion();
             return predicate.test(modVersion);
         } catch (Exception e) {
             return false;


### PR DESCRIPTION
Hopefully resolves #1. 

The `SemanticVersion` classes (i.e. `SemanticVersionPredicateParser`) were internal and did not work on Quilt, so I replaced them with the `Version` classes (i.e. `VersionPredicate`).

This builds and runs fine on my local version of Quilt Loader 0.17.1-beta4 with Minecraft 1.19. Please let me know if any changes could be made or if there is a better way to do this, as I am still new to writing Minecraft mods.